### PR TITLE
make building tests optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,14 @@ endif ()
 # analysis tools.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-include(CTest)
-enable_testing()
+option(AEON_ENABLE_TESTING "Enable testing." ON)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/dep/cmake")
+if (AEON_ENABLE_TESTING)
+    include(CTest)
+    enable_testing()
+endif ()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/dep/cmake")
 
 include(Dependencies)
 handle_dependencies_file("${CMAKE_SOURCE_DIR}/dependencies.txt")

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -84,4 +84,6 @@ install(
     ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()

--- a/src/fonts/CMakeLists.txt
+++ b/src/fonts/CMakeLists.txt
@@ -53,4 +53,6 @@ install(
     ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()

--- a/src/imaging/CMakeLists.txt
+++ b/src/imaging/CMakeLists.txt
@@ -118,4 +118,6 @@ install(
     ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -101,5 +101,8 @@ install(
     ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()
+
 add_subdirectory(benchmarks)

--- a/src/midi/CMakeLists.txt
+++ b/src/midi/CMakeLists.txt
@@ -57,4 +57,6 @@ install(
     ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()

--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -97,4 +97,6 @@ install(
     ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -54,4 +54,6 @@ install(
     ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()

--- a/src/ptree/CMakeLists.txt
+++ b/src/ptree/CMakeLists.txt
@@ -58,4 +58,6 @@ install(
     DESTINATION include
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()

--- a/src/rdp/CMakeLists.txt
+++ b/src/rdp/CMakeLists.txt
@@ -60,4 +60,6 @@ install(
     ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()

--- a/src/sockets/CMakeLists.txt
+++ b/src/sockets/CMakeLists.txt
@@ -113,4 +113,6 @@ install(
     ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()

--- a/src/streams/CMakeLists.txt
+++ b/src/streams/CMakeLists.txt
@@ -90,4 +90,6 @@ install(
     DESTINATION include
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()

--- a/src/tracelog/CMakeLists.txt
+++ b/src/tracelog/CMakeLists.txt
@@ -50,4 +50,6 @@ install(
     ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()

--- a/src/unicode/CMakeLists.txt
+++ b/src/unicode/CMakeLists.txt
@@ -56,4 +56,6 @@ install(
     ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()

--- a/src/utility/CMakeLists.txt
+++ b/src/utility/CMakeLists.txt
@@ -68,4 +68,6 @@ install(
     ARCHIVE DESTINATION lib
 )
 
-add_subdirectory(tests)
+if (AEON_ENABLE_TESTING)
+    add_subdirectory(tests)
+endif ()


### PR DESCRIPTION
like the title says, this pr makes building unit tests optional. This is ideal when libaeon is used as a submodule.